### PR TITLE
Return outputs as key-value pairs

### DIFF
--- a/packages/server/migrations/1717847143770_rename-output-to-logs.js
+++ b/packages/server/migrations/1717847143770_rename-output-to-logs.js
@@ -1,0 +1,22 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+    pgm.renameColumn('jobs', 'output', 'logs');
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.down = (pgm) => {
+    pgm.renameColumn('jobs', 'logs', 'output');
+};

--- a/packages/server/src/db/jobsRepository.ts
+++ b/packages/server/src/db/jobsRepository.ts
@@ -20,14 +20,14 @@ export async function markJobComplete(id: JobEntityId, assets: Asset[], output: 
     }
 
     return await getClient().query(
-        'UPDATE jobs SET status = $1, completed_at = $2, output = $3 WHERE id = $4',
+        'UPDATE jobs SET status = $1, completed_at = $2, logs = $3 WHERE id = $4',
         [JobStatus.Completed, new Date(), output, id]
     );
 }
 
 export async function markJobFailed(id: JobEntityId, output: string) {
     return await getClient().query(
-        'UPDATE jobs SET status = $1, completed_at = $2, output = $3 WHERE id = $4',
+        'UPDATE jobs SET status = $1, completed_at = $2, logs = $3 WHERE id = $4',
         [JobStatus.Failed, new Date(), output, id]
     );
 }

--- a/packages/server/src/types/asset.ts
+++ b/packages/server/src/types/asset.ts
@@ -1,4 +1,4 @@
 export interface Asset {
     name: string
-    storedPath: string
+    url: string
 }

--- a/packages/server/src/types/database.ts
+++ b/packages/server/src/types/database.ts
@@ -27,5 +27,5 @@ export type JobEntity = UnsavedJobEntity & {
     id: JobEntityId,
     created_at: Date,
     completed_at?: Date
-    assets?: Asset[]
+    outputs?: Record<string, string> // record of assets name (user provided) and url (generated)
 }

--- a/packages/server/tests/workflow.test.ts
+++ b/packages/server/tests/workflow.test.ts
@@ -15,5 +15,5 @@ test("workflow toCommandArguments", async () => {
 
     const command = toCommandArguments(workflow);
 
-    expect(command).toStrictEqual(["-i", "input.mp4", "-y", "output.mp4"])
+    expect(command).toStrictEqual(["-hide_banner", "-i", "input.mp4", "-y", "output.mp4"])
 });


### PR DESCRIPTION
Pending due decision of the field name change. Currently, we already have `output` for the ffmpeg logs, therefore not sure if naming it `outputs` is the right way. Alternatives?
- results
- files
- assets (as it was before)
- outputs (and rename the `output` field)