### PR TITLE
Add missing keys to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,8 @@ root = true
 
 [*]
 end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Two of the six standard [keys](https://editorconfig.org/) were missing.

[_source_](https://github.com/szepeviktor/github-repository-inspection)
