### PR TITLE
Mark Asset DB Records as Deleted Post-S3 Deletion

### DIFF
--- a/packages/client/src/JobEntity.ts
+++ b/packages/client/src/JobEntity.ts
@@ -14,7 +14,8 @@ type JobMetadata = {
         job_id: number
         name: string | null
         size_bytes: number
-        type: 'input' | 'output',
+        type: 'input' | 'output'
+        deleted_at: string | null
         ffprobe: FFprobeResult
     }[]
 }

--- a/packages/client/src/StreamPot.ts
+++ b/packages/client/src/StreamPot.ts
@@ -7,9 +7,20 @@ export type StreamPotOptions = {
     baseUrl?: string;
 }
 
+type Asset = {
+    id: number
+    job_id: number
+    deleted_at: string | null
+    created_at: string
+    type: 'output'
+    name: string
+    stored_path: string
+    url: string
+}
+
 type DeleteAssetsResponse = {
     success: boolean;
-    deletedAssets: Record<string, string>[];
+    deletedAssets: Asset[]
 }
 
 export default class StreamPot {

--- a/packages/server/migrations/1746605819411_add-deleted-at-to-asset.js
+++ b/packages/server/migrations/1746605819411_add-deleted-at-to-asset.js
@@ -1,0 +1,22 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+    pgm.sql(`ALTER TABLE assets ADD COLUMN deleted_at TIMESTAMP DEFAULT NULL;`);
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.down = (pgm) => {
+    pgm.sql(`ALTER TABLE assets DROP COLUMN deleted_at;`);
+};

--- a/packages/server/src/db/assetsRepository.ts
+++ b/packages/server/src/db/assetsRepository.ts
@@ -1,0 +1,33 @@
+import { JobEntity, JobEntityId } from '../types'
+import { OutputAsset, SavedAsset, SavedInputAsset, SavedOutputAsset } from '../types/asset';
+import getClient from "./db"
+
+export async function addAssets(job: JobEntity, assets: OutputAsset[]): Promise<SavedAsset[]> {
+    const outputs: SavedOutputAsset[] = (await getClient().query(
+        'INSERT INTO assets (job_id, name, stored_path, url, type) VALUES ' +
+        assets.map((_, i) => `($1, $${2 + i * 3}, $${3 + i * 3}, $${4 + i * 3}, $${5 + i * 3})`).join(', ') +
+        ' RETURNING *',
+        [job.id, ...assets.flatMap(asset => [asset.name, asset.storedPath, asset.url, 'output'])]
+    )).rows
+    const inputs: SavedInputAsset[] = (await getClient().query(
+        'INSERT INTO assets (job_id, url, type) VALUES ' +
+        job.payload.filter(action => action.name === 'input').map((_, i) => `($1, $${2 + i * 2}, $${3 + i * 2})`).join(', ') +
+        ' RETURNING *',
+        [job.id, ...job.payload.filter(action => action.name === 'input').flatMap(action => [action.value[0], "input"])]
+    )).rows
+    return [...outputs, ...inputs]
+}
+
+export async function getAssetsByJobId(id: JobEntityId): Promise<SavedOutputAsset[]> {
+    return (await getClient().query(
+        'SELECT * FROM assets WHERE job_id = $1 AND type = $2 AND deleted_at IS NULL',
+        [id, 'output'])
+    ).rows
+}
+
+export async function markAssetAsDeleted(assetId: number): Promise<SavedOutputAsset> {
+    return (await getClient().query(
+        'UPDATE assets SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING *',
+        [assetId]
+    )).rows[0];
+}

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,0 +1,5 @@
+export * from './db';
+
+export * from './jobsRepository';
+export * from './assetsRepository';
+export * from './metadataRepository';

--- a/packages/server/src/db/jobsRepository.ts
+++ b/packages/server/src/db/jobsRepository.ts
@@ -39,7 +39,10 @@ export async function getJobWithAssets(id: JobEntityId): Promise<JobEntity | nul
     if (jobRes.rows.length === 0) return null;
 
     const job = jobRes.rows[0];
-    const assets: OutputAsset[] = (await client.query("SELECT name, url FROM assets WHERE job_id = $1 AND type = 'output'", [id])).rows;
+    const assets: OutputAsset[] = (await client.query(
+        "SELECT name, url, stored_path as storedPath FROM assets WHERE job_id = $1 AND type = 'output' AND deleted_at IS NULL",
+        [id]
+    )).rows;
     const metadata = (await client.query('SELECT * FROM job_metadata WHERE job_id = $1', [id])).rows;
     const assetMetadata = (await client.query('SELECT * FROM asset_metadata WHERE job_id = $1', [id])).rows;
 

--- a/packages/server/src/db/jobsRepository.ts
+++ b/packages/server/src/db/jobsRepository.ts
@@ -1,6 +1,5 @@
-import { Asset, JobEntity, JobEntityId, JobStatus, UnsavedJobEntity } from '../types'
-import { OutputAsset, SavedAsset, SavedInputAsset, SavedOutputAsset } from '../types/asset';
-import { JobMetadata } from '../types';
+import { JobEntity, JobEntityId, JobStatus, UnsavedJobEntity } from '../types'
+import { OutputAsset, SavedAsset, SavedOutputAsset } from '../types/asset';
 import getClient from "./db"
 
 export async function addJob(data: UnsavedJobEntity): Promise<JobEntity> {
@@ -10,35 +9,6 @@ export async function addJob(data: UnsavedJobEntity): Promise<JobEntity> {
     )
 
     return rows.rows[0] as JobEntity
-}
-
-export async function setMetadata(metadata: JobMetadata) {
-    await getClient().query(
-        'INSERT INTO job_metadata (job_id, job_duration_ms, output_bytes, input_bytes) VALUES ($1, $2, $3, $4)',
-        [metadata.job_id, metadata.job_duration_ms, metadata.input_bytes, metadata.output_bytes]
-    );
-    for (const asset of metadata.assets) {
-        await getClient().query(
-            'INSERT INTO asset_metadata (job_id, asset_id, size_bytes, type, name, ffprobe) VALUES ($1, $2, $3, $4, $5, $6)',
-            [metadata.job_id, asset.id, asset.size, asset.type, asset.name, JSON.stringify(asset.ffprobe)]
-        );
-    }
-}
-
-export async function addAssets(job: JobEntity, assets: OutputAsset[]): Promise<SavedAsset[]> {
-    const outputs: SavedOutputAsset[] = (await getClient().query(
-        'INSERT INTO assets (job_id, name, stored_path, url, type) VALUES ' +
-        assets.map((_, i) => `($1, $${2 + i * 3}, $${3 + i * 3}, $${4 + i * 3}, $${5 + i * 3})`).join(', ') +
-        ' RETURNING *',
-        [job.id, ...assets.flatMap(asset => [asset.name, asset.storedPath, asset.url, 'output'])]
-    )).rows
-    const inputs: SavedInputAsset[] = (await getClient().query(
-        'INSERT INTO assets (job_id, url, type) VALUES ' +
-        job.payload.filter(action => action.name === 'input').map((_, i) => `($1, $${2 + i * 2}, $${3 + i * 2})`).join(', ') +
-        ' RETURNING *',
-        [job.id, ...job.payload.filter(action => action.name === 'input').flatMap(action => [action.value[0], "input"])]
-    )).rows
-    return [...outputs, ...inputs]
 }
 
 export async function markJobComplete(id: JobEntityId, output: string) {
@@ -69,16 +39,16 @@ export async function getJobWithAssets(id: JobEntityId): Promise<JobEntity | nul
     if (jobRes.rows.length === 0) return null;
 
     const job = jobRes.rows[0];
-    const assetsRes = await client.query('SELECT name, url FROM assets WHERE job_id = $1', [id]);
-    const metadataRes = await client.query('SELECT * FROM job_metadata WHERE job_id = $1', [id]);
-    const assetMetadataRes = await client.query('SELECT * FROM asset_metadata WHERE job_id = $1', [id]);
+    const assets: OutputAsset[] = (await client.query("SELECT name, url FROM assets WHERE job_id = $1 AND type = 'output'", [id])).rows;
+    const metadata = (await client.query('SELECT * FROM job_metadata WHERE job_id = $1', [id])).rows;
+    const assetMetadata = (await client.query('SELECT * FROM asset_metadata WHERE job_id = $1', [id])).rows;
 
     return <JobEntity>{
         ...job,
-        outputs: assetsToOutputs(assetsRes.rows),
-        metadata: metadataRes.rows.length > 0 ? {
-            ...metadataRes.rows[0],
-            assets: assetMetadataRes.rows.map(row => ({
+        outputs: assetsToOutputs(assets),
+        metadata: metadata.length > 0 ? {
+            ...metadata[0],
+            assets: assetMetadata.map(row => ({
                 ...row,
                 ffprobe: typeof row.ffprobe === 'string' ? JSON.parse(row.ffprobe) : row.ffprobe
             }))

--- a/packages/server/src/db/metadataRepository.ts
+++ b/packages/server/src/db/metadataRepository.ts
@@ -1,0 +1,15 @@
+import { JobMetadata } from '../types';
+import getClient from "./db"
+
+export async function setMetadata(metadata: JobMetadata) {
+    await getClient().query(
+        'INSERT INTO job_metadata (job_id, job_duration_ms, output_bytes, input_bytes) VALUES ($1, $2, $3, $4)',
+        [metadata.job_id, metadata.job_duration_ms, metadata.input_bytes, metadata.output_bytes]
+    );
+    for (const asset of metadata.assets) {
+        await getClient().query(
+            'INSERT INTO asset_metadata (job_id, asset_id, size_bytes, type, name, ffprobe) VALUES ($1, $2, $3, $4, $5, $6)',
+            [metadata.job_id, asset.id, asset.size, asset.type, asset.name, JSON.stringify(asset.ffprobe)]
+        );
+    }
+}

--- a/packages/server/src/db/metadataRepository.ts
+++ b/packages/server/src/db/metadataRepository.ts
@@ -4,7 +4,7 @@ import getClient from "./db"
 export async function setMetadata(metadata: JobMetadata) {
     await getClient().query(
         'INSERT INTO job_metadata (job_id, job_duration_ms, output_bytes, input_bytes) VALUES ($1, $2, $3, $4)',
-        [metadata.job_id, metadata.job_duration_ms, metadata.input_bytes, metadata.output_bytes]
+        [metadata.job_id, metadata.job_duration_ms, metadata.output_bytes, metadata.input_bytes]
     );
     for (const asset of metadata.assets) {
         await getClient().query(

--- a/packages/server/src/metadata.ts
+++ b/packages/server/src/metadata.ts
@@ -1,10 +1,10 @@
 import { executeFFProbe } from "./ffmpeg/ffprobe";
 import { JobEntity, SavedAsset, JobEntityId, JobMetadata } from "./types";
-import * as jobsRepository from './db/jobsRepository';
+import { setMetadata } from './db';
 
 export async function generateMetadata(job: JobEntity, assetsWithIds: SavedAsset[], startTime: number) {
     const metadata = await getMetadata(job.id, assetsWithIds, startTime);
-    await jobsRepository.setMetadata(metadata);
+    await setMetadata(metadata);
 }
 
 export async function getMetadata(jobId: JobEntityId, assets: SavedAsset[], startTime: number): Promise<JobMetadata> {

--- a/packages/server/src/queue/workers.ts
+++ b/packages/server/src/queue/workers.ts
@@ -1,6 +1,6 @@
 import { Worker } from "bullmq";
 import { QueueJob } from "../types";
-import { getJobWithAssets } from "../db/jobsRepository";
+import { getJobWithAssets } from "../db";
 import processWorkflow from "../actions/processWorkflow";
 import connection from "./connection";
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,13 +11,14 @@ import {
     Transformation,
     FfmpegActionsRequest,
     type FfmpegActionsRequestType,
+    SavedOutputAsset,
 } from './types'
 import {
     JobNotFoundError,
     DeletionError,
     NoOutputsError
 } from './errors'
-import { addJob, getAllJobs, getJobWithAssets } from './db/jobsRepository'
+import { addJob, getAllJobs, getJobWithAssets } from './db'
 import { validateBearerToken } from './auth'
 import { shouldUseAPIKey } from './config'
 import { deleteFilesByJobId } from './storage'
@@ -73,7 +74,7 @@ export type DeleteAssetsResponse = Array<{ key: string, url: string, filename: s
 app.delete<{
     Params: { jobId: JobEntityId },
     Reply: {
-        200: { deletedAssets: DeleteAssetsResponse },
+        200: { deletedAssets: SavedOutputAsset[] },
         204: null,
         404: { message: string },
         500: { message: string }

--- a/packages/server/src/types/asset.ts
+++ b/packages/server/src/types/asset.ts
@@ -1,5 +1,3 @@
-import { FFprobeResult } from "./"
-
 interface BaseAsset {
     url: string
 }
@@ -18,12 +16,14 @@ export type Asset = InputAsset | OutputAsset
 export interface SavedInputAsset extends InputAsset {
     id: number
     job_id: number
+    deleted_at: string | null
     created_at: string
 }
 
 export interface SavedOutputAsset extends OutputAsset {
     id: number
     job_id: number
+    deleted_at: string | null
     created_at: string
 }
 


### PR DESCRIPTION
When files are deleted from S3, their corresponding records in the `assets` database table are now marked with a `deleted_at` timestamp.

**Key Changes:**

* A `deleted_at TIMESTAMP DEFAULT NULL` column was added to the `assets` table via database migration.
* The S3 deletion logic in `packages/server/src/storage.ts` was updated to set this `deleted_at` timestamp on the corresponding database asset record after successful S3 file deletion (using a new `markAssetAsDeleted` database function).
* Database queries that fetch active assets (e.g., in `packages/server/src/db/jobsRepository.ts` and the new `packages/server/src/db/assetsRepository.ts`) now include a `WHERE deleted_at IS NULL` condition.
* Asset-related database operations were refactored, with many functions moved to the new `packages/server/src/db/assetsRepository.ts`.
* The API response for asset deletion operations (defined in `packages/server/src/server.ts`) now returns a list of the database asset records that were updated with the `deleted_at` timestamp.
* Client-side type definitions in `packages/client/src/JobEntity.ts` and `packages/client/src/StreamPot.ts` were updated to include the `deleted_at` property for assets.